### PR TITLE
Support windows

### DIFF
--- a/wsgicli.py
+++ b/wsgicli.py
@@ -204,7 +204,9 @@ def import_from_path(import_path):
 def find_modules_from_path(import_path):
     import_from_path(import_path)
 
-    parent_path = lambda path: os.path.abspath(os.path.join(path, ".."))
+    def parent_path(path):
+        return os.path.abspath(os.path.join(path, ".."))
+
     site_dirs = site.getsitepackages()
     lib_dirs = [parent_path(path) for path in site_dirs]
 

--- a/wsgicli.py
+++ b/wsgicli.py
@@ -212,8 +212,6 @@ def find_modules_from_path(import_path):
         if path[-4:] in ('.pyo', '.pyc'):
             path = path[:-1]
         if path and os.path.exists(path):
-            # Standard libraries are in lib/python3.x/...
-            # And third party libraries are in lib/python3.x/site-packages/...
             if all(not path.startswith(lib_dir) for lib_dir in lib_dirs):
                 yield module
 

--- a/wsgicli.py
+++ b/wsgicli.py
@@ -204,11 +204,8 @@ def import_from_path(import_path):
 def find_modules_from_path(import_path):
     import_from_path(import_path)
 
-    def parent_path(path):
-        return os.path.abspath(os.path.join(path, ".."))
-
     site_dirs = site.getsitepackages()
-    lib_dirs = [parent_path(path) for path in site_dirs]
+    lib_dirs = [os.path.dirname(path) for path in site_dirs]
 
     for module in sys.modules.values():
         path = getattr(module, '__file__', '')

--- a/wsgicli.py
+++ b/wsgicli.py
@@ -1,8 +1,8 @@
 import click
 from importlib.machinery import SourceFileLoader
 import os
-import sys
 import site
+import sys
 import time
 import threading
 import _thread


### PR DESCRIPTION
pathを"/"でsplitしている場所があり、windowsでは動かないので修正しました。
windowsではlib/pythonを含まないディレクトリに標準ライブラリやサードパーティのライブラリがインストールされるのでそれに対応しました。